### PR TITLE
一部の画像のパスが切れてたので修復

### DIFF
--- a/workshop/content/20-typescript/30-hello-cdk/_index.md
+++ b/workshop/content/20-typescript/30-hello-cdk/_index.md
@@ -13,6 +13,6 @@ Gateway endpoint in front of it.
 Users will be able to hit any URL in the endpoint and they'll receive a
 heartwarming greeting from our function.
 
-![](/images/hello-arch.png)
+![](/aws-cdk-intro-workshop/images/hello-arch.png)
 
 First, let's clean up the sample code.

--- a/workshop/content/20-typescript/40-hit-counter/_index.md
+++ b/workshop/content/20-typescript/40-hit-counter/_index.md
@@ -11,7 +11,7 @@ construct can be attached to any Lambda function that's used as an API Gateway
 backend, and it will count how many requests were issued to each URL path. It
 will store this in a DynamoDB table.
 
-![](/images/hit-counter.png)
+![](/aws-cdk-intro-workshop/images/hit-counter.png)
 
 ## See Also
 

--- a/workshop/content/20-typescript/50-table-viewer/_index.md
+++ b/workshop/content/20-typescript/50-table-viewer/_index.md
@@ -10,5 +10,4 @@ In this chapter we will import a construct library called
 [cdk-dynamo-table-viewer](https://www.npmjs.com/package/cdk-dynamo-table-viewer)
 into our project and install it on our hit counter table.
 
-![](/images/table-viewer.png)
-
+![](/aws-cdk-intro-workshop/images/table-viewer.png)

--- a/workshop/content/30-python/30-hello-cdk/_index.md
+++ b/workshop/content/30-python/30-hello-cdk/_index.md
@@ -13,6 +13,6 @@ Gateway endpoint in front of it.
 Users will be able to hit any URL in the endpoint and they'll receive a
 heartwarming greeting from our function.
 
-![](/images/hello-arch.png)
+![](/aws-cdk-intro-workshop/images/hello-arch.png)
 
 First, let's clean up the sample code.

--- a/workshop/content/30-python/40-hit-counter/_index.md
+++ b/workshop/content/30-python/40-hit-counter/_index.md
@@ -11,7 +11,7 @@ construct can be attached to any Lambda function that's used as an API Gateway
 backend, and it will count how many requests were issued to each URL path. It
 will store this in a DynamoDB table.
 
-![](/images/hit-counter.png)
+![](/aws-cdk-intro-workshop/images/hit-counter.png)
 
 ## See Also
 

--- a/workshop/content/30-python/50-table-viewer/_index.md
+++ b/workshop/content/30-python/50-table-viewer/_index.md
@@ -10,5 +10,4 @@ In this chapter we will import a construct library called
 [cdk-dynamo-table-viewer](https://www.npmjs.com/package/cdk-dynamo-table-viewer)
 into our project and install it on our hit counter table.
 
-![](/images/table-viewer.png)
-
+![](/aws-cdk-intro-workshop/images/table-viewer.png)

--- a/workshop/content/40-dotnet/30-hello-cdk/_index.md
+++ b/workshop/content/40-dotnet/30-hello-cdk/_index.md
@@ -13,6 +13,6 @@ Gateway endpoint in front of it.
 Users will be able to hit any URL in the endpoint and they'll receive a
 heartwarming greeting from our function.
 
-![](/images/hello-arch.png)
+![](/aws-cdk-intro-workshop/images/hello-arch.png)
 
 First, let's clean up the sample code.

--- a/workshop/content/40-dotnet/50-table-viewer/_index.md
+++ b/workshop/content/40-dotnet/50-table-viewer/_index.md
@@ -10,5 +10,4 @@ In this chapter we will import a construct library called
 [DynamoTableViewer](https://www.nuget.org/packages/Cdklabs.DynamoTableViewer/)
 into our project and install it on our hit counter table.
 
-![](/images/table-viewer.png)
-
+![](/aws-cdk-intro-workshop/images/table-viewer.png)

--- a/workshop/content/50-java/30-hello-cdk/_index.md
+++ b/workshop/content/50-java/30-hello-cdk/_index.md
@@ -13,6 +13,6 @@ Gateway endpoint in front of it.
 Users will be able to hit any URL in the endpoint and they'll receive a
 heartwarming greeting from our function.
 
-![](/images/hello-arch.png)
+![](/aws-cdk-intro-workshop/images/hello-arch.png)
 
 First, let's clean up the sample code.

--- a/workshop/content/50-java/50-table-viewer/_index.md
+++ b/workshop/content/50-java/50-table-viewer/_index.md
@@ -10,4 +10,4 @@ In this chapter we will import a construct library called
 [cdk-dynamo-table-view](https://search.maven.org/artifact/io.github.cdklabs/cdk-dynamo-table-view/0.2.0/jar)
 into our project and install it on our hit counter table.
 
-![](/images/table-viewer.png)
+![](/aws-cdk-intro-workshop/images/table-viewer.png)


### PR DESCRIPTION
↓のページのリンクが切れちゃってる。
https://jaws-ug-cdk.github.io/aws-cdk-intro-workshop/20-typescript/30-hello-cdk.html

github-pagesに乗せたときの↓の修正によってリンクが切れてしまってた。
https://github.com/jaws-ug-cdk/aws-cdk-intro-workshop/commit/4602f48472bd12191c1133ea9c5f9792b978a805#diff-8b424d9a961619bb657a7f85b0a3c121e6b19d554fb20eb1cfb63e7151d53986